### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A idle timeout class in iOS. Allows custom idle timeout functionality that handl
 
 ## Installation
 
-1. APIdleManager can be installed via [Cocoapods](http://cocoapods.org/) by adding `pod 'ApIdleManager'` to your podfile, or you can manually add `APIdleManager.h` and `APIdleManager.m` into your project.
+1. APIdleManager can be installed via [CocoaPods](http://cocoapods.org/) by adding `pod 'ApIdleManager'` to your podfile, or you can manually add `APIdleManager.h` and `APIdleManager.m` into your project.
 2. Implement the `onTimeout` block to instaniate the idle manager, start your idle timer, and implement and functionality that is necessary for when the application times out. Without any block implementation, the class will not function properly.
 
     ```


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
